### PR TITLE
Add advisor factory for sharing all subscribed products.

### DIFF
--- a/lib/tai/advisors/factories/one_for_all_products.ex
+++ b/lib/tai/advisors/factories/one_for_all_products.ex
@@ -1,0 +1,23 @@
+defmodule Tai.Advisors.Factories.OneForAllProducts do
+  @moduledoc """
+  Advisor factory for sharing all subscribed products.
+
+  Use this to receive order book updates from all subscribed products in that group.
+  """
+  @behaviour Tai.Advisors.Factory
+
+  @type group :: Tai.AdvisorGroup.t()
+  @type spec :: Tai.Advisor.spec()
+
+  @spec advisor_specs(group) :: [spec]
+  def advisor_specs(group) do
+    opts = [
+      group_id: group.id,
+      advisor_id: :main,
+      products: group.products,
+      config: group.config
+    ]
+
+    [{group.advisor, opts}]
+  end
+end

--- a/test/tai/advisors/factories/one_for_all_products_test.exs
+++ b/test/tai/advisors/factories/one_for_all_products_test.exs
@@ -1,0 +1,26 @@
+defmodule Tai.Advisors.Factories.OneForAllProductsTest do
+  use ExUnit.Case, async: true
+  alias Tai.Advisors.Factories.OneForAllProducts
+
+  @products [
+    struct(Tai.Venues.Product, %{venue_id: :venue_a, symbol: :btc_usdt}),
+    struct(Tai.Venues.Product, %{venue_id: :venue_b, symbol: :etc_usdt})
+  ]
+  @group_with_products struct(Tai.AdvisorGroup, %{
+                         id: :group_a,
+                         advisor: MyAdvisor,
+                         factory: OneForAllProducts,
+                         products: @products,
+                         config: %{hello: :world}
+                       })
+
+  test "returns one advisor spec for all products in one advisor group" do
+    assert [spec] = OneForAllProducts.advisor_specs(@group_with_products)
+
+    assert {MyAdvisor, opts} = spec
+    assert Keyword.fetch!(opts, :group_id) == :group_a
+    assert Keyword.fetch!(opts, :advisor_id) == :main
+    assert Keyword.fetch!(opts, :config) == %{hello: :world}
+    assert Keyword.fetch!(opts, :products) == @products
+  end
+end


### PR DESCRIPTION
Currently, the default factory (`OnePerVenueAndProduct`) sends updates where messages are scoped to each product per venue.

`OneForAllProducts ` allows receiving messages from all products within that advisor group.