### PR TITLE
BitMex dead man's switch

### DIFF
--- a/apps/tai/lib/tai/venue_adapters/binance/stream_supervisor.ex
+++ b/apps/tai/lib/tai/venue_adapters/binance/stream_supervisor.ex
@@ -5,16 +5,22 @@ defmodule Tai.VenueAdapters.Binance.StreamSupervisor do
   @type channel :: Tai.Venues.Adapter.channel()
   @type product :: Tai.Venues.Product.t()
 
-  @spec start_link(venue_id: venue_id, channels: [channel], accounts: map, products: [product]) ::
+  @spec start_link(
+          venue_id: venue_id,
+          channels: [channel],
+          accounts: map,
+          products: [product],
+          opts: map
+        ) ::
           Supervisor.on_start()
-  def start_link([venue_id: venue_id, channels: _, accounts: _, products: _] = args) do
+  def start_link([venue_id: venue_id, channels: _, accounts: _, products: _, opts: _] = args) do
     Supervisor.start_link(__MODULE__, args, name: :"#{__MODULE__}_#{venue_id}")
   end
 
   # TODO: Make this configurable
   @base_url "wss://stream.binance.com:9443/stream"
 
-  def init(venue_id: venue_id, channels: _, accounts: accounts, products: products) do
+  def init(venue_id: venue_id, channels: _, accounts: accounts, products: products, opts: _) do
     # TODO: Potentially this could use new order books? Send the change quote
     # event to subscribing advisors?
     order_books =

--- a/apps/tai/lib/tai/venue_adapters/bitmex/stream/connection.ex
+++ b/apps/tai/lib/tai/venue_adapters/bitmex/stream/connection.ex
@@ -11,11 +11,12 @@ defmodule Tai.VenueAdapters.Bitmex.Stream.Connection do
             venue: venue_id,
             channels: [channel_name],
             account: {account_id, map} | nil,
-            products: [product]
+            products: [product],
+            opts: map
           }
 
-    @enforce_keys ~w(venue channels products)a
-    defstruct ~w(venue channels account products)a
+    @enforce_keys ~w(venue channels products opts)a
+    defstruct ~w(venue channels account products opts)a
   end
 
   @type product :: Venues.Product.t()
@@ -27,16 +28,25 @@ defmodule Tai.VenueAdapters.Bitmex.Stream.Connection do
           url: String.t(),
           venue: venue_id,
           account: {account_id, account_config} | nil,
-          products: [product]
+          products: [product],
+          opts: map
         ) :: {:ok, pid} | {:error, term}
   def start_link(
         url: url,
         venue: venue,
         channels: channels,
         account: account,
-        products: products
+        products: products,
+        opts: opts
       ) do
-    state = %State{venue: venue, channels: channels, account: account, products: products}
+    state = %State{
+      venue: venue,
+      channels: channels,
+      account: account,
+      products: products,
+      opts: opts
+    }
+
     name = venue |> to_name
     headers = auth_headers(state.account)
     WebSockex.start_link(url, __MODULE__, state, name: name, extra_headers: headers)

--- a/apps/tai/lib/tai/venue_adapters/bitmex/stream_supervisor.ex
+++ b/apps/tai/lib/tai/venue_adapters/bitmex/stream_supervisor.ex
@@ -25,7 +25,7 @@ defmodule Tai.VenueAdapters.Bitmex.StreamSupervisor do
         channels: channels,
         accounts: accounts,
         products: products,
-        opts: _
+        opts: opts
       ) do
     # TODO: Potentially this could use new order books? Send the change quote
     # event to subscribing advisors?
@@ -68,7 +68,8 @@ defmodule Tai.VenueAdapters.Bitmex.StreamSupervisor do
          venue: venue_id,
          channels: channels,
          account: accounts |> Map.to_list() |> List.first(),
-         products: products
+         products: products,
+         opts: opts
        ]}
     ]
 

--- a/apps/tai/lib/tai/venue_adapters/bitmex/stream_supervisor.ex
+++ b/apps/tai/lib/tai/venue_adapters/bitmex/stream_supervisor.ex
@@ -5,16 +5,28 @@ defmodule Tai.VenueAdapters.Bitmex.StreamSupervisor do
   @type channel :: Tai.Venues.Adapter.channel()
   @type product :: Tai.Venues.Product.t()
 
-  @spec start_link(venue_id: venue_id, channels: [channel], accounts: map, products: [product]) ::
+  @spec start_link(
+          venue_id: venue_id,
+          channels: [channel],
+          accounts: map,
+          products: [product],
+          opts: map
+        ) ::
           Supervisor.on_start()
-  def start_link([venue_id: venue_id, channels: _, accounts: _, products: _] = args) do
+  def start_link([venue_id: venue_id, channels: _, accounts: _, products: _, opts: _] = args) do
     Supervisor.start_link(__MODULE__, args, name: :"#{__MODULE__}_#{venue_id}")
   end
 
   # TODO: Make this configurable
   @url "wss://" <> ExBitmex.Rest.HTTPClient.domain() <> "/realtime"
 
-  def init(venue_id: venue_id, channels: channels, accounts: accounts, products: products) do
+  def init(
+        venue_id: venue_id,
+        channels: channels,
+        accounts: accounts,
+        products: products,
+        opts: _
+      ) do
     # TODO: Potentially this could use new order books? Send the change quote
     # event to subscribing advisors?
     order_books =

--- a/apps/tai/lib/tai/venue_adapters/mock/stream_supervisor.ex
+++ b/apps/tai/lib/tai/venue_adapters/mock/stream_supervisor.ex
@@ -4,13 +4,25 @@ defmodule Tai.VenueAdapters.Mock.StreamSupervisor do
   @type channel :: Tai.Venues.Adapter.channel()
   @type product :: Tai.Venues.Product.t()
 
-  @spec start_link(venue_id: atom, channels: [channel], accounts: map, products: [product]) ::
+  @spec start_link(
+          venue_id: atom,
+          channels: [channel],
+          accounts: map,
+          products: [product],
+          opts: map
+        ) ::
           Supervisor.on_start()
-  def start_link([venue_id: venue_id, channels: _, accounts: _, products: _] = args) do
+  def start_link([venue_id: venue_id, channels: _, accounts: _, products: _, opts: _] = args) do
     Supervisor.start_link(__MODULE__, args, name: :"#{__MODULE__}_#{venue_id}")
   end
 
-  def init(venue_id: venue_id, channels: channels, accounts: accounts, products: products) do
+  def init(
+        venue_id: venue_id,
+        channels: channels,
+        accounts: accounts,
+        products: products,
+        opts: _
+      ) do
     order_books =
       products
       |> Enum.map(fn p ->

--- a/apps/tai/lib/tai/venue_adapters/okex/stream_supervisor.ex
+++ b/apps/tai/lib/tai/venue_adapters/okex/stream_supervisor.ex
@@ -6,16 +6,28 @@ defmodule Tai.VenueAdapters.OkEx.StreamSupervisor do
   @type channel :: Tai.Venues.Adapter.channel()
   @type product :: Tai.Venues.Product.t()
 
-  @spec start_link(venue_id: atom, channels: [channel], accounts: map, products: [product]) ::
+  @spec start_link(
+          venue_id: atom,
+          channels: [channel],
+          accounts: map,
+          products: [product],
+          opts: map
+        ) ::
           Supervisor.on_start()
-  def start_link([venue_id: venue_id, channels: _, accounts: _, products: _] = args) do
+  def start_link([venue_id: venue_id, channels: _, accounts: _, products: _, opts: _] = args) do
     Supervisor.start_link(__MODULE__, args, name: :"#{__MODULE__}_#{venue_id}")
   end
 
   # TODO: Make this configurable
   @endpoint "wss://real.okex.com:10442/ws/v3"
 
-  def init(venue_id: venue_id, channels: channels, accounts: accounts, products: products) do
+  def init(
+        venue_id: venue_id,
+        channels: channels,
+        accounts: accounts,
+        products: products,
+        opts: _
+      ) do
     # TODO: Potentially this could use new order books? Send the change quote
     # event to subscribing advisors?
     order_books =

--- a/apps/tai/lib/tai/venues/adapter.ex
+++ b/apps/tai/lib/tai/venues/adapter.ex
@@ -30,7 +30,8 @@ defmodule Tai.Venues.Adapter do
           channels: [channel],
           products: String.t(),
           accounts: map,
-          timeout: non_neg_integer
+          timeout: non_neg_integer,
+          opts: map
         }
 
   @callback stream_supervisor :: atom
@@ -49,6 +50,6 @@ defmodule Tai.Venues.Adapter do
   @callback cancel_order(order, credentials) ::
               {:ok, cancel_response} | {:error, cancel_order_error_reason}
 
-  @enforce_keys ~w(id adapter channels products accounts timeout)a
-  defstruct ~w(id adapter channels products accounts timeout)a
+  @enforce_keys ~w(id adapter channels products accounts timeout opts)a
+  defstruct ~w(id adapter channels products accounts timeout opts)a
 end

--- a/apps/tai/lib/tai/venues/boot/stream.ex
+++ b/apps/tai/lib/tai/venues/boot/stream.ex
@@ -9,7 +9,8 @@ defmodule Tai.Venues.Boot.Stream do
       adapter.id,
       adapter.channels,
       adapter.accounts,
-      products
+      products,
+      adapter.opts
     )
   end
 end

--- a/apps/tai/lib/tai/venues/config.ex
+++ b/apps/tai/lib/tai/venues/config.ex
@@ -16,6 +16,7 @@ defmodule Tai.Venues.Config do
               channels: Keyword.get(params, :channels, []),
               products: Keyword.get(params, :products, "*"),
               accounts: Keyword.get(params, :accounts, %{}),
+              opts: Keyword.get(params, :opts, %{}),
               timeout: Keyword.get(params, :timeout, config.adapter_timeout)
             }
 

--- a/apps/tai/lib/tai/venues/streams_supervisor.ex
+++ b/apps/tai/lib/tai/venues/streams_supervisor.ex
@@ -19,14 +19,21 @@ defmodule Tai.Venues.StreamsSupervisor do
           venue_id :: venue_id,
           channels :: [channel],
           accounts :: map,
-          products :: [product]
+          products :: [product],
+          opts :: map
         ) :: DynamicSupervisor.on_start_child()
   def start_stream(Tai.Venues.NullStreamSupervisor, _, _, _, _), do: :ignore
 
-  def start_stream(stream_supervisor, venue_id, channels, accounts, products) do
+  def start_stream(stream_supervisor, venue_id, channels, accounts, products, opts) do
     spec =
       {stream_supervisor,
-       [venue_id: venue_id, channels: channels, accounts: accounts, products: products]}
+       [
+         venue_id: venue_id,
+         channels: channels,
+         accounts: accounts,
+         products: products,
+         opts: opts
+       ]}
 
     DynamicSupervisor.start_child(__MODULE__, spec)
   end

--- a/config/dev.exs.example
+++ b/config/dev.exs.example
@@ -33,7 +33,9 @@ config :tai,
           api_secret: {:system_file, "BITMEX_SECRET"}
         }
       },
-      opts: %{}
+      opts: %{
+        autocancel: %{ping_interval_ms: 15_000, cancel_after_ms: 60_000}
+      }
     ],
     okex: [
       enabled: true,

--- a/config/dev.exs.example
+++ b/config/dev.exs.example
@@ -32,7 +32,8 @@ config :tai,
           api_key: {:system_file, "BITMEX_API_KEY"},
           api_secret: {:system_file, "BITMEX_SECRET"}
         }
-      }
+      },
+      opts: %{}
     ],
     okex: [
       enabled: true,

--- a/config/prod.exs.example
+++ b/config/prod.exs.example
@@ -34,6 +34,7 @@ config :tai,
           api_secret: {:system_file, "BITMEX_SECRET"}
         }
       },
+      opts: %{},
       timeout: 60_000
     ],
     binance: [

--- a/config/prod.exs.example
+++ b/config/prod.exs.example
@@ -34,7 +34,9 @@ config :tai,
           api_secret: {:system_file, "BITMEX_SECRET"}
         }
       },
-      opts: %{},
+      opts: %{
+        autocancel: %{ping_interval_ms: 15_000, cancel_after_ms: 60_000}
+      },
       timeout: 60_000
     ],
     binance: [

--- a/config/test.exs
+++ b/config/test.exs
@@ -18,7 +18,8 @@ config(:tai,
     mock: [
       enabled: true,
       adapter: Tai.VenueAdapters.Mock,
-      accounts: %{main: %{}}
+      accounts: %{main: %{}},
+      opts: %{}
     ],
     bitmex: [
       enabled: true,
@@ -28,7 +29,8 @@ config(:tai,
           api_key: {:system_file, "BITMEX_API_KEY"},
           api_secret: {:system_file, "BITMEX_API_SECRET"}
         }
-      }
+      },
+      opts: %{}
     ],
     okex: [
       enabled: true,
@@ -39,7 +41,8 @@ config(:tai,
           api_secret: {:system_file, "OKEX_API_SECRET"},
           api_passphrase: {:system_file, "OKEX_API_PASSPHRASE"}
         }
-      }
+      },
+      opts: %{}
     ],
     okex_futures: [
       enabled: true,
@@ -50,7 +53,8 @@ config(:tai,
           api_secret: {:system_file, "OKEX_API_SECRET"},
           api_passphrase: {:system_file, "OKEX_API_PASSPHRASE"}
         }
-      }
+      },
+      opts: %{}
     ],
     okex_swap: [
       enabled: true,
@@ -61,7 +65,8 @@ config(:tai,
           api_secret: {:system_file, "OKEX_API_SECRET"},
           api_passphrase: {:system_file, "OKEX_API_PASSPHRASE"}
         }
-      }
+      },
+      opts: %{}
     ],
     binance: [
       enabled: true,

--- a/config/test.exs
+++ b/config/test.exs
@@ -30,7 +30,9 @@ config(:tai,
           api_secret: {:system_file, "BITMEX_API_SECRET"}
         }
       },
-      opts: %{}
+      opts: %{
+        autocancel: %{ping_interval_ms: 15_000, cancel_after_ms: 60_000}
+      }
     ],
     okex: [
       enabled: true,


### PR DESCRIPTION
This adds generic `opts` to adapter config. Using this we can pass in venue specific options.
This allows us to configure [BitMex's dead man's switch](https://www.bitmex.com/app/wsAPI#Dead-Mans-Switch-Auto-Cancel) to auto-cancel orders if there is a network issue like so:

```elixir
config :tai,
  venues: %{
    bitmex: [
      enabled: true,
      adapter: Tai.VenueAdapters.Bitmex,
      products: "xbtz18 xbth19",
      accounts: %{
        main: %{
          api_key: {:system_file, "BITMEX_API_KEY"},
          api_secret: {:system_file, "BITMEX_SECRET"}
        }
      },
      opts: %{
        autocancel: %{ping_interval_ms: 15_000, cancel_after_ms: 60_000}
      }
    ],
```

With above config, we ping the server every 15 seconds, and if the server does not receive any messages for 60 seconds it will auto-cancel any open orders.