### PR TITLE
Advisor terminate/2

### DIFF
--- a/apps/tai/lib/tai/advisor.ex
+++ b/apps/tai/lib/tai/advisor.ex
@@ -82,6 +82,7 @@ defmodule Tai.Advisor do
 
       @doc false
       def init(state) do
+        Process.flag(:trap_exit, true)
         {:ok, state, {:continue, :subscribe_to_products}}
       end
 

--- a/apps/tai/lib/tai/advisor.ex
+++ b/apps/tai/lib/tai/advisor.ex
@@ -256,6 +256,9 @@ defmodule Tai.Advisor do
           end
         end
       end
+
+      def terminate(_reason, _state), do: :ok
+      defoverridable terminate: 2
     end
   end
 end


### PR DESCRIPTION
This allows use of [GenServer.terminate/2](https://hexdocs.pm/elixir/GenServer.html#c:terminate/2) callback to be used in advisor cleanup after termination.

A simple use case would be to close all open orders when advisor is terminated:

```elixir
defmodule MyAdvisor do
  use Tai.Advisor
  # ...
  def terminate(_reason, %{store: %{orders: orders}} = _state) do
    orders
    |> Enum.map(&Tai.Trading.Orders.cancel/1)
  end
end

```