### PR TITLE
Allow Advisor.init/1 override

### DIFF
--- a/apps/tai/lib/tai/advisor.ex
+++ b/apps/tai/lib/tai/advisor.ex
@@ -85,6 +85,8 @@ defmodule Tai.Advisor do
         {:ok, state, {:continue, :subscribe_to_products}}
       end
 
+      defoverridable init: 1
+
       @doc false
       def handle_continue(:subscribe_to_products, state) do
         state.products

--- a/apps/tai/test/tai/advisor_test.exs
+++ b/apps/tai/test/tai/advisor_test.exs
@@ -9,39 +9,15 @@ defmodule Tai.AdvisorTest do
 
   describe ".start_link" do
     test "can initialize run store" do
-      start_supervised!(
-        {MyAdvisor,
-         [
-           group_id: :init_run_store,
-           advisor_id: :my_advisor,
-           products: [],
-           config: %{},
-           store: %{initialized: true},
-           trades: []
-         ]}
-      )
-
-      advisor_name = Tai.Advisor.to_name(:init_run_store, :my_advisor)
-      state = :sys.get_state(advisor_name)
+      pid = start!(:init_run_store, :my_advisor, store: %{initialized: true})
+      state = :sys.get_state(pid)
 
       assert state.store.initialized == true
     end
 
     test "can initialize trades" do
-      start_supervised!(
-        {MyAdvisor,
-         [
-           group_id: :init_trades,
-           advisor_id: :my_advisor,
-           products: [],
-           config: %{},
-           store: %{},
-           trades: [:a]
-         ]}
-      )
-
-      advisor_name = Tai.Advisor.to_name(:init_trades, :my_advisor)
-      state = :sys.get_state(advisor_name)
+      pid = start!(:init_trades, :my_advisor, trades: [:a])
+      state = :sys.get_state(pid)
 
       assert state.trades == [:a]
     end
@@ -50,25 +26,23 @@ defmodule Tai.AdvisorTest do
   describe ".cast_order_updated/4" do
     setup do
       Process.register(self(), :test)
-      advisor_name = start!(:group_a, :my_advisor)
-      {:ok, %{advisor_name: advisor_name}}
+      pid = start!(:group_a, :my_advisor)
+      %{pid: pid}
     end
 
-    test "executes the given callback function", %{advisor_name: advisor_name} do
+    test "executes the given callback function", %{pid: pid} do
       callback = fn old_order, updated_order, state ->
         send(:test, {:fired_order_updated_callback, old_order, updated_order, state})
         :ok
       end
 
-      Tai.Advisor.cast_order_updated(advisor_name, :old_order, :updated_order, callback)
+      Tai.Advisor.cast_order_updated(pid, :old_order, :updated_order, callback)
 
       assert_receive {:fired_order_updated_callback, :old_order, :updated_order,
                       %Tai.Advisor.State{}}
     end
 
-    test "can update the run store map with the return value of the callback", %{
-      advisor_name: advisor_name
-    } do
+    test "can update the run store map with the return value of the callback", %{pid: pid} do
       callback = fn old_order, updated_order, state ->
         send(:test, {:fired_order_updated_callback, old_order, updated_order, state})
         counter = state.store |> Map.get(:counter, 0)
@@ -77,24 +51,22 @@ defmodule Tai.AdvisorTest do
         {:ok, new_store}
       end
 
-      Tai.Advisor.cast_order_updated(advisor_name, :old_order, :updated_order, callback)
+      Tai.Advisor.cast_order_updated(pid, :old_order, :updated_order, callback)
 
       assert_receive {:fired_order_updated_callback, :old_order, :updated_order, original_state}
       assert original_state.store == %{}
 
-      Tai.Advisor.cast_order_updated(advisor_name, :old_order, :updated_order, callback)
+      Tai.Advisor.cast_order_updated(pid, :old_order, :updated_order, callback)
 
       assert_receive {:fired_order_updated_callback, :old_order, :updated_order, updated_state}
       assert updated_state.store == %{counter: 1}
     end
 
-    test "broadcasts an event when an error is raised in the callback", %{
-      advisor_name: advisor_name
-    } do
+    test "broadcasts an event when an error is raised in the callback", %{pid: pid} do
       Tai.Events.firehose_subscribe()
       callback = fn _, _, _ -> raise "Callback Error!!!" end
 
-      Tai.Advisor.cast_order_updated(advisor_name, :raise_error, :updated_order, callback)
+      Tai.Advisor.cast_order_updated(pid, :raise_error, :updated_order, callback)
 
       assert_receive {Tai.Event, %Tai.Events.AdvisorOrderUpdatedError{} = event, _}
       assert event.error == %RuntimeError{message: "Callback Error!!!"}
@@ -104,25 +76,23 @@ defmodule Tai.AdvisorTest do
   describe ".cast_order_updated/5" do
     setup do
       Process.register(self(), :test)
-      advisor_name = start!(:group_a, :my_advisor)
-      {:ok, %{advisor_name: advisor_name}}
+      pid = start!(:group_a, :my_advisor)
+      %{pid: pid}
     end
 
-    test "executes the given callback function", %{advisor_name: advisor_name} do
+    test "executes the given callback function", %{pid: pid} do
       callback = fn old_order, updated_order, opts, state ->
         send(:test, {:fired_order_updated_callback, old_order, updated_order, opts, state})
         :ok
       end
 
-      Tai.Advisor.cast_order_updated(advisor_name, :old_order, :updated_order, callback, :opts)
+      Tai.Advisor.cast_order_updated(pid, :old_order, :updated_order, callback, :opts)
 
       assert_receive {:fired_order_updated_callback, :old_order, :updated_order, :opts,
                       %Tai.Advisor.State{}}
     end
 
-    test "can update the run store map with the return value of the callback", %{
-      advisor_name: advisor_name
-    } do
+    test "can update the run store map with the return value of the callback", %{pid: pid} do
       callback = fn old_order, updated_order, opts, state ->
         send(:test, {:fired_order_updated_callback, old_order, updated_order, opts, state})
         counter = state.store |> Map.get(:counter, 0)
@@ -131,14 +101,14 @@ defmodule Tai.AdvisorTest do
         {:ok, new_store}
       end
 
-      Tai.Advisor.cast_order_updated(advisor_name, :old_order, :updated_order, callback, :opts)
+      Tai.Advisor.cast_order_updated(pid, :old_order, :updated_order, callback, :opts)
 
       assert_receive {:fired_order_updated_callback, :old_order, :updated_order, :opts,
                       original_state}
 
       assert original_state.store == %{}
 
-      Tai.Advisor.cast_order_updated(advisor_name, :old_order, :updated_order, callback, :opts)
+      Tai.Advisor.cast_order_updated(pid, :old_order, :updated_order, callback, :opts)
 
       assert_receive {:fired_order_updated_callback, :old_order, :updated_order, :opts,
                       updated_state}
@@ -146,20 +116,23 @@ defmodule Tai.AdvisorTest do
       assert updated_state.store == %{counter: 1}
     end
 
-    test "broadcasts an event when an error is raised in the callback", %{
-      advisor_name: advisor_name
-    } do
+    test "broadcasts an event when an error is raised in the callback", %{pid: pid} do
       Tai.Events.firehose_subscribe()
       callback = fn _, _, _, _ -> raise "Callback Error!!!" end
 
-      Tai.Advisor.cast_order_updated(advisor_name, :raise_error, :updated_order, callback, :opts)
+      Tai.Advisor.cast_order_updated(pid, :raise_error, :updated_order, callback, :opts)
 
       assert_receive {Tai.Event, %Tai.Events.AdvisorOrderUpdatedError{} = event, _}
       assert event.error == %RuntimeError{message: "Callback Error!!!"}
     end
   end
 
-  defp start!(group_id, advisor_id) do
+  defp start!(group_id, advisor_id, opts \\ []) do
+    products = Keyword.get(opts, :products, [])
+    config = Keyword.get(opts, :config, %{})
+    trades = Keyword.get(opts, :trades, [])
+    run_store = Keyword.get(opts, :store, %{})
+
     start_supervised!({Tai.Events, 1})
 
     start_supervised!(
@@ -167,13 +140,11 @@ defmodule Tai.AdvisorTest do
        [
          group_id: group_id,
          advisor_id: advisor_id,
-         products: [],
-         config: %{},
-         store: %{},
-         trades: []
+         products: products,
+         config: config,
+         store: run_store,
+         trades: trades
        ]}
     )
-
-    Tai.Advisor.to_name(group_id, advisor_id)
   end
 end


### PR DESCRIPTION
Allows overriding of init for customisation.

```elixir
defmodule MyAdvisor do
  use Tai.Advisor
  def handle_inside_quote(_, _, _, _, state), do: {:ok, state.store}
  def init(state) do
    IO.puts("Custom init")
    super(state)
  end
end
```