### PR TITLE
[WIP] Subscribe to data responders

### DIFF
--- a/apps/examples/lib/examples/create_and_cancel_pending_order/advisor.ex
+++ b/apps/examples/lib/examples/create_and_cancel_pending_order/advisor.ex
@@ -1,7 +1,7 @@
 defmodule Examples.CreateAndCancelPendingOrder.Advisor do
   use Tai.Advisor
 
-  def handle_inside_quote(venue_id, product_symbol, _inside_quote, _changes, state) do
+  def handle_inside_quote(venue_id, product_symbol, _data, state) do
     if Tai.Trading.OrderStore.count() == 0 do
       {:ok, product} = Tai.Venues.ProductStore.find({venue_id, product_symbol})
 

--- a/apps/examples/lib/examples/fill_or_kill_orders/advisor.ex
+++ b/apps/examples/lib/examples/fill_or_kill_orders/advisor.ex
@@ -8,7 +8,7 @@ defmodule Examples.FillOrKillOrders.Advisor do
 
   require Logger
 
-  def handle_inside_quote(venue_id, product_symbol, _inside_quote, _changes, state) do
+  def handle_inside_quote(venue_id, product_symbol, _data, state) do
     if Tai.Trading.OrderStore.count() == 0 do
       {:ok, product} = Tai.Venues.ProductStore.find({venue_id, product_symbol})
 

--- a/apps/examples/lib/examples/log_spread/advisor.ex
+++ b/apps/examples/lib/examples/log_spread/advisor.ex
@@ -9,11 +9,13 @@ defmodule Examples.LogSpread.Advisor do
         venue_id,
         product_symbol,
         # wait until we have quotes for both sides of the order book
-        %Tai.Markets.Quote{
-          bid: %Tai.Markets.PriceLevel{},
-          ask: %Tai.Markets.PriceLevel{}
-        } = market_quote,
-        _changes,
+        %{
+          market_quote:
+            %Tai.Markets.Quote{
+              bid: %Tai.Markets.PriceLevel{},
+              ask: %Tai.Markets.PriceLevel{}
+            } = market_quote
+        },
         state
       ) do
     bid_price = market_quote.bid.price |> Decimal.cast()
@@ -32,5 +34,5 @@ defmodule Examples.LogSpread.Advisor do
   end
 
   # ignore quotes that don't have both sides of the order book
-  def handle_inside_quote(_, _, _, _, state), do: {:ok, state.store}
+  def handle_inside_quote(_, _, _, state), do: {:ok, state.store}
 end

--- a/apps/tai/lib/tai/advisor.ex
+++ b/apps/tai/lib/tai/advisor.ex
@@ -48,11 +48,14 @@ defmodule Tai.Advisor do
     GenServer.cast(name, {:order_updated, old_order, updated_order, callback, opts})
   end
 
-  defmacro __using__(_) do
+  defmacro __using__(opts \\ []) do
+    subscribe_to = Keyword.get(opts, :subscribe_to, [:changes, :market_quote])
+
     quote location: :keep do
       use GenServer
 
       @behaviour Tai.Advisor
+      @subscribe_to unquote(subscribe_to)
 
       def start_link(
             group_id: group_id,
@@ -64,6 +67,7 @@ defmodule Tai.Advisor do
           ) do
         name = Tai.Advisor.to_name(group_id, advisor_id)
         market_quotes = %Tai.Advisors.MarketQuotes{data: %{}}
+        config = Map.put(config || %{}, :subscribe_to, @subscribe_to)
 
         state = %State{
           group_id: group_id,

--- a/apps/tai/lib/tai/advisor.ex
+++ b/apps/tai/lib/tai/advisor.ex
@@ -27,14 +27,12 @@ defmodule Tai.Advisor do
   @type venue_id :: Tai.Venues.Adapter.venue_id()
   @type product_symbol :: Tai.Venues.Product.symbol()
   @type order :: Tai.Trading.Order.t()
-  @type market_quote :: Tai.Markets.Quote.t()
-  @type changes :: term
   @type group_id :: Tai.AdvisorGroup.id()
   @type id :: State.id()
   @type run_store :: State.run_store()
   @type state :: State.t()
 
-  @callback handle_inside_quote(venue_id, product_symbol, market_quote, changes, state) ::
+  @callback handle_inside_quote(venue_id, product_symbol, map, state) ::
               {:ok, run_store}
 
   @spec to_name(group_id, id) :: atom
@@ -225,8 +223,7 @@ defmodule Tai.Advisor do
                    handle_inside_quote(
                      venue_id,
                      product_symbol,
-                     current_inside_quote,
-                     changes,
+                     %{market_quote: current_inside_quote, changes: changes},
                      state
                    ) do
               Map.put(state, :store, new_store)

--- a/apps/tai/lib/tai/advisor_responders/changes.ex
+++ b/apps/tai/lib/tai/advisor_responders/changes.ex
@@ -1,0 +1,10 @@
+defmodule Tai.AdvisorResponders.Changes do
+  alias Tai.AdvisorResponders.Responder
+  @behaviour Responder
+
+  @impl Responder
+  def respond({response, state}, {_, _, _, changes}) do
+    new_response = Map.put(response, :changes, changes)
+    {:ok, {new_response, state}}
+  end
+end

--- a/apps/tai/lib/tai/advisor_responders/market_quote.ex
+++ b/apps/tai/lib/tai/advisor_responders/market_quote.ex
@@ -1,0 +1,68 @@
+defmodule Tai.AdvisorResponders.MarketQuote do
+  alias Tai.AdvisorResponders.Responder
+  @behaviour Responder
+
+  @impl Responder
+  def respond({response, state}, {:order_book_changes, venue_id, product_symbol, changes}) do
+    previous_inside_quote =
+      state.market_quotes |> Tai.Advisors.MarketQuotes.for(venue_id, product_symbol)
+
+    new_state =
+      if inside_quote_is_stale?(previous_inside_quote, changes) do
+        cache_inside_quote(state, venue_id, product_symbol)
+      else
+        state
+      end
+
+    new_quote = new_state.market_quotes |> Tai.Advisors.MarketQuotes.for(venue_id, product_symbol)
+    new_reseponse = Map.put(response, :market_quote, new_quote)
+
+    {:ok, {new_reseponse, new_state}}
+  end
+
+  def respond({response, state}, {:order_book_snapshot, venue_id, product_symbol, _snapshot}) do
+    new_state = cache_inside_quote(state, venue_id, product_symbol)
+    new_quote = new_state.market_quotes |> Tai.Advisors.MarketQuotes.for(venue_id, product_symbol)
+    new_reseponse = Map.put(response, :market_quote, new_quote)
+    {:ok, {new_reseponse, new_state}}
+  end
+
+  defp cache_inside_quote(state, venue_id, product_symbol) do
+    {:ok, current_inside_quote} = Tai.Markets.OrderBook.inside_quote(venue_id, product_symbol)
+    key = {venue_id, product_symbol}
+    old_market_quotes = state.market_quotes
+    updated_market_quotes_data = Map.put(old_market_quotes.data, key, current_inside_quote)
+    updated_market_quotes = Map.put(old_market_quotes, :data, updated_market_quotes_data)
+
+    state
+    |> Map.put(:market_quotes, updated_market_quotes)
+  end
+
+  defp inside_quote_is_stale?(previous_inside_quote, %Tai.Markets.OrderBook{
+         bids: bids,
+         asks: asks
+       }) do
+    (bids |> Enum.any?() && bids |> inside_bid_is_stale?(previous_inside_quote)) ||
+      (asks |> Enum.any?() && asks |> inside_ask_is_stale?(previous_inside_quote))
+  end
+
+  defp inside_bid_is_stale?(_bids, nil), do: true
+
+  defp inside_bid_is_stale?(bids, %Tai.Markets.Quote{} = prev_quote) do
+    bids
+    |> Enum.any?(fn {price, {size, _processed_at, _server_changed_at}} ->
+      price >= prev_quote.bid.price ||
+        (price == prev_quote.bid.price && size != prev_quote.bid.size)
+    end)
+  end
+
+  defp inside_ask_is_stale?(_asks, nil), do: true
+
+  defp inside_ask_is_stale?(asks, %Tai.Markets.Quote{} = prev_quote) do
+    asks
+    |> Enum.any?(fn {price, {size, _processed_at, _server_changed_at}} ->
+      price <= prev_quote.ask.price ||
+        (price == prev_quote.ask.price && size != prev_quote.ask.size)
+    end)
+  end
+end

--- a/apps/tai/lib/tai/advisor_responders/responder.ex
+++ b/apps/tai/lib/tai/advisor_responders/responder.ex
@@ -1,0 +1,13 @@
+defmodule Tai.AdvisorResponders.Responder do
+  @doc """
+  Receives orderbook changes and
+  """
+  @type state :: Tai.Advisor.State.t()
+  @type response :: map
+  @type action :: :order_book_changes | :order_book_snapshot
+  @type venue_id :: Tai.Venues.Adapter.venue_id()
+  @type product_symbol :: Tai.Venues.Product.symbol()
+
+  @callback respond({response, state}, {action, venue_id, product_symbol, map}) ::
+              {:ok, {response, state}}
+end

--- a/apps/tai/test/support/noop_advisor.ex
+++ b/apps/tai/test/support/noop_advisor.ex
@@ -1,7 +1,7 @@
 defmodule Support.NoopAdvisor do
   use Tai.Advisor
 
-  def handle_inside_quote(_, _, _, _, state) do
+  def handle_inside_quote(_, _, _, state) do
     {:ok, state.store}
   end
 end

--- a/apps/tai/test/tai/advisor_test.exs
+++ b/apps/tai/test/tai/advisor_test.exs
@@ -4,7 +4,7 @@ defmodule Tai.AdvisorTest do
 
   defmodule MyAdvisor do
     use Tai.Advisor
-    def handle_inside_quote(_, _, _, _, state), do: {:ok, state.store}
+    def handle_inside_quote(_, _, _, state), do: {:ok, state.store}
 
     def init(%Tai.Advisor.State{config: %{callback: callback}} = state) do
       callback.()

--- a/apps/tai/test/tai/advisors/handle_inside_quote_callback_test.exs
+++ b/apps/tai/test/tai/advisors/handle_inside_quote_callback_test.exs
@@ -4,12 +4,12 @@ defmodule Tai.Advisors.HandleInsideQuoteCallbackTest do
   defmodule MyAdvisor do
     use Tai.Advisor
 
-    def handle_inside_quote(feed_id, symbol, inside_quote, changes, state) do
+    def handle_inside_quote(feed_id, symbol, data, state) do
       if Map.has_key?(state.config, :error) do
         raise state.config.error
       end
 
-      send(:test, {feed_id, symbol, inside_quote, changes, state})
+      send(:test, {feed_id, symbol, data, state})
       {:ok, state.store}
     end
   end
@@ -17,8 +17,8 @@ defmodule Tai.Advisors.HandleInsideQuoteCallbackTest do
   defmodule ReturnAdvisor do
     use Tai.Advisor
 
-    def handle_inside_quote(venue_id, product_symbol, inside_quote, changes, state) do
-      send(:test, {venue_id, product_symbol, inside_quote, changes, state})
+    def handle_inside_quote(venue_id, product_symbol, data, state) do
+      send(:test, {venue_id, product_symbol, data, state})
       state.config[:return_val]
     end
   end
@@ -62,7 +62,8 @@ defmodule Tai.Advisors.HandleInsideQuoteCallbackTest do
 
     Tai.Markets.OrderBook.replace(snapshot)
 
-    assert_receive {:my_venue, :btc_usd, received_market_quote, received_snapshot,
+    assert_receive {:my_venue, :btc_usd,
+                    %{market_quote: received_market_quote, changes: received_snapshot},
                     %Tai.Advisor.State{}}
 
     assert %Tai.Markets.Quote{} = received_market_quote
@@ -99,21 +100,23 @@ defmodule Tai.Advisors.HandleInsideQuoteCallbackTest do
     assert_receive {
       :my_venue,
       :btc_usd,
-      %Tai.Markets.Quote{
-        bid: %Tai.Markets.PriceLevel{
-          price: 101.2,
-          size: 1.0,
-          processed_at: nil,
-          server_changed_at: nil
+      %{
+        market_quote: %Tai.Markets.Quote{
+          bid: %Tai.Markets.PriceLevel{
+            price: 101.2,
+            size: 1.0,
+            processed_at: nil,
+            server_changed_at: nil
+          },
+          ask: %Tai.Markets.PriceLevel{
+            price: 101.3,
+            size: 0.1,
+            processed_at: nil,
+            server_changed_at: nil
+          }
         },
-        ask: %Tai.Markets.PriceLevel{
-          price: 101.3,
-          size: 0.1,
-          processed_at: nil,
-          server_changed_at: nil
-        }
+        changes: ^changes_1
       },
-      ^changes_1,
       %Tai.Advisor.State{}
     }
 
@@ -129,21 +132,23 @@ defmodule Tai.Advisors.HandleInsideQuoteCallbackTest do
     assert_receive {
       :my_venue,
       :btc_usd,
-      %Tai.Markets.Quote{
-        bid: %Tai.Markets.PriceLevel{
-          price: 101.2,
-          size: 1.1,
-          processed_at: nil,
-          server_changed_at: nil
+      %{
+        market_quote: %Tai.Markets.Quote{
+          bid: %Tai.Markets.PriceLevel{
+            price: 101.2,
+            size: 1.1,
+            processed_at: nil,
+            server_changed_at: nil
+          },
+          ask: %Tai.Markets.PriceLevel{
+            price: 101.3,
+            size: 0.1,
+            processed_at: nil,
+            server_changed_at: nil
+          }
         },
-        ask: %Tai.Markets.PriceLevel{
-          price: 101.3,
-          size: 0.1,
-          processed_at: nil,
-          server_changed_at: nil
-        }
+        changes: ^changes_2
       },
-      ^changes_2,
       %Tai.Advisor.State{}
     }
   end
@@ -163,21 +168,23 @@ defmodule Tai.Advisors.HandleInsideQuoteCallbackTest do
     assert_receive {
       :my_venue,
       :btc_usd,
-      %Tai.Markets.Quote{
-        bid: %Tai.Markets.PriceLevel{
-          price: 101.2,
-          size: 1.0,
-          processed_at: nil,
-          server_changed_at: nil
+      %{
+        market_quote: %Tai.Markets.Quote{
+          bid: %Tai.Markets.PriceLevel{
+            price: 101.2,
+            size: 1.0,
+            processed_at: nil,
+            server_changed_at: nil
+          },
+          ask: %Tai.Markets.PriceLevel{
+            price: 101.3,
+            size: 0.1,
+            processed_at: nil,
+            server_changed_at: nil
+          }
         },
-        ask: %Tai.Markets.PriceLevel{
-          price: 101.3,
-          size: 0.1,
-          processed_at: nil,
-          server_changed_at: nil
-        }
+        changes: ^changes_1
       },
-      ^changes_1,
       %Tai.Advisor.State{}
     }
 
@@ -193,21 +200,23 @@ defmodule Tai.Advisors.HandleInsideQuoteCallbackTest do
     assert_receive {
       :my_venue,
       :btc_usd,
-      %Tai.Markets.Quote{
-        bid: %Tai.Markets.PriceLevel{
-          price: 101.2,
-          size: 1.0,
-          processed_at: nil,
-          server_changed_at: nil
+      %{
+        market_quote: %Tai.Markets.Quote{
+          bid: %Tai.Markets.PriceLevel{
+            price: 101.2,
+            size: 1.0,
+            processed_at: nil,
+            server_changed_at: nil
+          },
+          ask: %Tai.Markets.PriceLevel{
+            price: 101.3,
+            size: 0.2,
+            processed_at: nil,
+            server_changed_at: nil
+          }
         },
-        ask: %Tai.Markets.PriceLevel{
-          price: 101.3,
-          size: 0.2,
-          processed_at: nil,
-          server_changed_at: nil
-        }
+        changes: ^changes_2
       },
-      ^changes_2,
       %Tai.Advisor.State{}
     }
   end
@@ -227,8 +236,7 @@ defmodule Tai.Advisors.HandleInsideQuoteCallbackTest do
     assert_receive {
       :my_venue,
       :btc_usd,
-      %Tai.Markets.Quote{},
-      ^snapshot,
+      %{market_quote: %Tai.Markets.Quote{}, changes: ^snapshot},
       %Tai.Advisor.State{advisor_id: :my_advisor, store: %{}}
     }
 
@@ -244,8 +252,7 @@ defmodule Tai.Advisors.HandleInsideQuoteCallbackTest do
     assert_receive {
       :my_venue,
       :btc_usd,
-      %Tai.Markets.Quote{},
-      ^changes,
+      %{market_quote: %Tai.Markets.Quote{}, changes: ^changes},
       %Tai.Advisor.State{advisor_id: :my_advisor, store: %{hello: "world"}}
     }
   end
@@ -325,7 +332,7 @@ defmodule Tai.Advisors.HandleInsideQuoteCallbackTest do
       assert event.error == %RuntimeError{message: "!!!This is an ERROR!!!"}
       assert [stack_1 | _] = event.stacktrace
 
-      assert {Tai.Advisors.HandleInsideQuoteCallbackTest.MyAdvisor, :handle_inside_quote, 5,
+      assert {Tai.Advisors.HandleInsideQuoteCallbackTest.MyAdvisor, :handle_inside_quote, 4,
               [file: _, line: _]} = stack_1
     end
 


### PR DESCRIPTION
Extracts changes processors into own concern. This allows advisors to subscribe to desired change updates, as well as custom preparation of data to feed into advisor by doing so:

```
defmodule MyAdvisor do
  use Tai.Advisor,
    subscribe_to: [
      Tai.AdvisorResponders.Changes,
      Tai.AdvisorResponders.MarketQuote,
      MyMacdProcessor
    ]
...
```

- [ ] Test `Tai.AdvisorResponders.Changes`
- [ ] Test `Tai.AdvisorResponders.MarketQuote`