### PR TITLE
Allow filtering products with custom filter function

### DIFF
--- a/apps/tai/lib/tai/venues/adapter.ex
+++ b/apps/tai/lib/tai/venues/adapter.ex
@@ -28,7 +28,7 @@ defmodule Tai.Venues.Adapter do
           id: atom,
           adapter: module,
           channels: [channel],
-          products: String.t(),
+          products: String.t() | function,
           accounts: map,
           timeout: non_neg_integer,
           opts: map

--- a/apps/tai/lib/tai/venues/boot/products.ex
+++ b/apps/tai/lib/tai/venues/boot/products.ex
@@ -20,6 +20,9 @@ defmodule Tai.Venues.Boot.Products do
     end
   end
 
+  defp filter(all_products, filters) when is_function(filters),
+    do: all_products |> filters.()
+
   defp filter(all_products, filters) do
     all_products
     |> Enum.reduce(

--- a/apps/tai/test/tai/venues/boot/products_test.exs
+++ b/apps/tai/test/tai/venues/boot/products_test.exs
@@ -40,4 +40,23 @@ defmodule Tai.Venues.Boot.ProductsTest do
                       filtered: 1
                     }, _}
   end
+
+  test "allows filtering with custom function" do
+    config =
+      Tai.Config.parse(
+        venues: %{
+          my_venue: [
+            enabled: true,
+            adapter: MyAdapter,
+            products: &custom_filter_helper(&1, :eth_usd)
+          ]
+        }
+      )
+
+    %{my_venue: adapter} = Tai.Venues.Config.parse_adapters(config)
+    assert {:ok, [%{symbol: :eth_usd}]} = Tai.Venues.Boot.Products.hydrate(adapter)
+  end
+
+  def custom_filter_helper(products, exact_match),
+    do: Enum.filter(products, &(&1.symbol == exact_match))
 end


### PR DESCRIPTION
Juice is great for simple cases, but not for more complex filtering. For example: subscribe to all products containing `btc`.