### PR TITLE
Venue symbol instrument lookup

### DIFF
--- a/apps/tai/lib/tai/venues/product_store.ex
+++ b/apps/tai/lib/tai/venues/product_store.ex
@@ -21,7 +21,7 @@ defmodule Tai.Venues.ProductStore do
   end
 
   def handle_call({:upsert, product}, _from, state) do
-    record = {{product.venue_id, product.symbol}, product}
+    record = {{product.venue_id, product.symbol, product.venue_symbol}, product}
     :ets.insert(__MODULE__, record)
     {:reply, :ok, state}
   end
@@ -44,8 +44,9 @@ defmodule Tai.Venues.ProductStore do
   end
 
   @spec find({venue_id, symbol}) :: {:ok, product} | {:error, :not_found}
-  def find(key) do
-    with [[%Tai.Venues.Product{} = product]] <- :ets.match(__MODULE__, {key, :"$1"}) do
+  def find({venue_id, symbol}) do
+    with [[%Tai.Venues.Product{} = product]] <-
+           :ets.match(__MODULE__, {{venue_id, symbol, :_}, :"$1"}) do
       {:ok, product}
     else
       [] -> {:error, :not_found}

--- a/apps/tai/lib/tai/venues/product_store.ex
+++ b/apps/tai/lib/tai/venues/product_store.ex
@@ -73,8 +73,8 @@ defmodule Tai.Venues.ProductStore do
   @spec all :: [product]
   def all do
     __MODULE__
-    |> :ets.select([{{:_, :_}, [], [:"$_"]}])
-    |> Enum.map(fn {{_, _}, product} -> product end)
+    |> :ets.tab2list()
+    |> Enum.map(&elem(&1, 1))
   end
 
   defp create_ets_table do

--- a/apps/tai/lib/tai/venues/product_store.ex
+++ b/apps/tai/lib/tai/venues/product_store.ex
@@ -3,6 +3,7 @@ defmodule Tai.Venues.ProductStore do
 
   @type product :: Tai.Venues.Product.t()
   @type symbol :: Tai.Venues.Product.symbol()
+  @type venue_symbol :: Tai.Venues.Product.venue_symbol()
   @type venue_id :: Tai.Venues.Adapter.venue_id()
 
   def start_link(_) do
@@ -47,6 +48,16 @@ defmodule Tai.Venues.ProductStore do
   def find({venue_id, symbol}) do
     with [[%Tai.Venues.Product{} = product]] <-
            :ets.match(__MODULE__, {{venue_id, symbol, :_}, :"$1"}) do
+      {:ok, product}
+    else
+      [] -> {:error, :not_found}
+    end
+  end
+
+  @spec find_by_venue_symbol({venue_id, venue_symbol}) :: {:ok, product} | {:error, :not_found}
+  def find_by_venue_symbol({venue_id, venue_symbol}) do
+    with [[%Tai.Venues.Product{} = product]] <-
+           :ets.match(__MODULE__, {{venue_id, :_, venue_symbol}, :"$1"}) do
       {:ok, product}
     else
       [] -> {:error, :not_found}

--- a/apps/tai/test/tai/venues/product_store_test.exs
+++ b/apps/tai/test/tai/venues/product_store_test.exs
@@ -12,7 +12,8 @@ defmodule Tai.Venues.ProductStoreTest do
     product =
       struct(Tai.Venues.Product, %{
         venue_id: :my_venue,
-        symbol: :btc_usdt
+        symbol: :btc_usdt,
+        venue_symbol: "BTCUSDT"
       })
 
     {:ok, %{product: product}}
@@ -22,7 +23,7 @@ defmodule Tai.Venues.ProductStoreTest do
     test "inserts the product into the 'products' ETS table", %{product: product} do
       assert Tai.Venues.ProductStore.upsert(product) == :ok
 
-      assert [{{:my_venue, :btc_usdt}, ^product}] =
+      assert [{{:my_venue, :btc_usdt, "BTCUSDT"}, ^product}] =
                :ets.lookup(Tai.Venues.ProductStore, {:my_venue, :btc_usdt})
     end
   end

--- a/apps/tai/test/tai/venues/product_store_test.exs
+++ b/apps/tai/test/tai/venues/product_store_test.exs
@@ -24,7 +24,7 @@ defmodule Tai.Venues.ProductStoreTest do
       assert Tai.Venues.ProductStore.upsert(product) == :ok
 
       assert [{{:my_venue, :btc_usdt, "BTCUSDT"}, ^product}] =
-               :ets.lookup(Tai.Venues.ProductStore, {:my_venue, :btc_usdt})
+               :ets.lookup(Tai.Venues.ProductStore, {:my_venue, :btc_usdt, "BTCUSDT"})
     end
   end
 
@@ -47,6 +47,20 @@ defmodule Tai.Venues.ProductStoreTest do
 
     test "returns an error tuple when the key is not found" do
       assert Tai.Venues.ProductStore.find({:my_venue_does_not_exist, :btc_usdt}) ==
+               {:error, :not_found}
+    end
+  end
+
+  describe "#find_by_venue_symbol" do
+    test "returns the product in an ok tuple", %{product: product} do
+      assert Tai.Venues.ProductStore.upsert(product) == :ok
+
+      assert {:ok, ^product} =
+               Tai.Venues.ProductStore.find_by_venue_symbol({:my_venue, "BTCUSDT"})
+    end
+
+    test "returns an error tuple when the key is not found" do
+      assert Tai.Venues.ProductStore.find_by_venue_symbol({:my_venue, "ETCUSDT"}) ==
                {:error, :not_found}
     end
   end


### PR DESCRIPTION
Some exchanges make it difficult to deconstruct their symbols when there is no breakpoint in between. `Tai.Venues.ProductStore.find_by_venue_symbol/1` will allow feeds to lookup the correct product for formatting using exchange's native instrument notation (e.g. `BTCUSDT`)