### PR TITLE
Parse and broadcast incoming trade data from Binance

### DIFF
--- a/apps/tai/lib/tai/venue_adapters/binance/stream/process_optional_channels.ex
+++ b/apps/tai/lib/tai/venue_adapters/binance/stream/process_optional_channels.ex
@@ -1,5 +1,6 @@
 defmodule Tai.VenueAdapters.Binance.Stream.ProcessOptionalChannels do
   use GenServer
+  alias Tai.VenueAdapters.Binance.Stream
 
   defmodule State do
     @type venue_id :: Tai.Venues.Adapter.venue_id()
@@ -22,6 +23,11 @@ defmodule Tai.VenueAdapters.Binance.Stream.ProcessOptionalChannels do
 
   @spec to_name(venue_id) :: atom
   def to_name(venue_id), do: :"#{__MODULE__}_#{venue_id}"
+
+  def handle_cast({%{"data" => %{"e" => "trade"} = trade}, received_at}, state) do
+    Stream.Trades.broadcast(trade, state.venue_id, received_at)
+    {:noreply, state}
+  end
 
   def handle_cast({msg, received_at}, state) do
     %Tai.Events.StreamMessageUnhandled{

--- a/apps/tai/lib/tai/venue_adapters/binance/stream/trades.ex
+++ b/apps/tai/lib/tai/venue_adapters/binance/stream/trades.ex
@@ -1,0 +1,46 @@
+defmodule Tai.VenueAdapters.Binance.Stream.Trades do
+  # {
+  #   "e": "trade",     // Event type
+  #   "E": 123456789,   // Event time
+  #   "s": "BNBBTC",    // Symbol
+  #   "t": 12345,       // Trade ID
+  #   "p": "0.001",     // Price
+  #   "q": "100",       // Quantity
+  #   "b": 88,          // Buyer order ID
+  #   "a": 50,          // Seller order ID
+  #   "T": 123456785,   // Trade time
+  #   "m": true,        // Is the buyer the market maker?
+  #   "M": true         // Ignore
+  # }
+  def broadcast(
+        %{
+          "s" => venue_symbol,
+          "T" => unix_timestamp,
+          "p" => price,
+          "q" => qty,
+          "m" => side,
+          "t" => venue_trade_id
+        },
+        venue_id,
+        received_at
+      ) do
+    {:ok, product} = Tai.Venues.ProductStore.find_by_venue_symbol({venue_id, venue_symbol})
+    {:ok, timestamp} = DateTime.from_unix(unix_timestamp, :millisecond)
+
+    Tai.Events.info(%Tai.Events.Trade{
+      venue_id: venue_id,
+      symbol: product.symbol,
+      received_at: received_at,
+      timestamp: timestamp,
+      price: price,
+      qty: qty,
+      side: side |> normalize_side,
+      venue_trade_id: venue_trade_id
+    })
+  end
+
+  # Translation may be incorrect: 买方是否是做市方。如true，则此次成交是一个主动卖出单，否则是一个主动买入单。
+  # https://github.com/binance-exchange/binance-official-api-docs/blob/master/web-socket-streams_CN.md#%E9%80%90%E7%AC%94%E4%BA%A4%E6%98%93
+  defp normalize_side(true), do: :sell
+  defp normalize_side(false), do: :buy
+end

--- a/apps/tai/test/tai/venue_adapters/binance/stream/trades_test.exs
+++ b/apps/tai/test/tai/venue_adapters/binance/stream/trades_test.exs
@@ -1,0 +1,47 @@
+defmodule Tai.VenueAdapters.Binance.Stream.TradesTest do
+  use ExUnit.Case, async: false
+  import Tai.TestSupport.Assertions.Event
+  alias Tai.VenueAdapters.Binance.Stream.ProcessOptionalChannels
+  alias Tai.{Events, Venues}
+
+  setup do
+    product =
+      struct(Venues.Product, %{
+        venue_id: :my_venue,
+        symbol: :bnb_btc,
+        venue_symbol: "BNBBTC"
+      })
+
+    start_supervised!({Tai.Events, 1})
+    start_supervised!({ProcessOptionalChannels, [venue_id: product.venue_id]})
+    start_supervised!(Venues.ProductStore)
+    Venues.ProductStore.upsert(product)
+
+    %{product: product}
+  end
+
+  test "broadcasts an event when public trade is received", %{product: product} do
+    Events.firehose_subscribe()
+    venue_trade_id = 42
+
+    trade = %{
+      "e" => "trade",
+      "E" => venue_trade_id,
+      "s" => product.venue_symbol,
+      "t" => 12345,
+      "p" => "0.001",
+      "q" => "100",
+      "b" => 88,
+      "a" => 50,
+      "T" => 123_456_785,
+      "m" => true,
+      "M" => true
+    }
+
+    product.venue_id
+    |> ProcessOptionalChannels.to_name()
+    |> GenServer.cast({%{"data" => trade}, :ignore})
+
+    assert_event(%Events.Trade{venue_trade_id: venue_trade_id})
+  end
+end


### PR DESCRIPTION
Allows subscription to optional `trades` channel on binance and receive public trades feed data

Depends on https://github.com/fremantle-capital/tai/pull/68