### PR TITLE
Subscribe to L2 order book on bitmex

### DIFF
--- a/apps/tai/lib/tai/venue_adapters/bitmex/stream/connection.ex
+++ b/apps/tai/lib/tai/venue_adapters/bitmex/stream/connection.ex
@@ -14,11 +14,12 @@ defmodule Tai.VenueAdapters.Bitmex.Stream.Connection do
             channels: [channel_name],
             account: {account_id, map} | nil,
             products: [product],
+            quote_depth: pos_integer,
             opts: map
           }
 
-    @enforce_keys ~w(venue routes channels products opts)a
-    defstruct ~w(venue routes channels account products opts)a
+    @enforce_keys ~w(venue routes channels products quote_depth opts)a
+    defstruct ~w(venue routes channels account products quote_depth opts)a
   end
 
   @type product :: Tai.Venues.Product.t()
@@ -32,6 +33,7 @@ defmodule Tai.VenueAdapters.Bitmex.Stream.Connection do
           venue: venue_id,
           account: {account_id, account_config} | nil,
           products: [product],
+          quote_depth: pos_integer,
           opts: map
         ) :: {:ok, pid} | {:error, term}
   def start_link(
@@ -40,6 +42,7 @@ defmodule Tai.VenueAdapters.Bitmex.Stream.Connection do
         channels: channels,
         account: account,
         products: products,
+        quote_depth: quote_depth,
         opts: opts
       ) do
     routes = %{
@@ -54,6 +57,7 @@ defmodule Tai.VenueAdapters.Bitmex.Stream.Connection do
       channels: channels,
       account: account,
       products: products,
+      quote_depth: quote_depth,
       opts: opts
     }
 

--- a/apps/tai/lib/tai/venue_adapters/bitmex/stream_supervisor.ex
+++ b/apps/tai/lib/tai/venue_adapters/bitmex/stream_supervisor.ex
@@ -45,6 +45,7 @@ defmodule Tai.VenueAdapters.Bitmex.StreamSupervisor do
          channels: venue_adapter.channels,
          account: account,
          products: products,
+         quote_depth: venue_adapter.quote_depth,
          opts: venue_adapter.opts
        ]}
     ]


### PR DESCRIPTION
When `quote_depth` is above 25, venue adapter should subscribe to appropriate WS channel to receive required order book information