### PR TITLE
Reduce ProcessQuote bottleneck.

### DIFF
--- a/apps/tai/lib/tai/markets/process_quote.ex
+++ b/apps/tai/lib/tai/markets/process_quote.ex
@@ -77,8 +77,8 @@ defmodule Tai.Markets.ProcessQuote do
   defp price_points(side, depth, sort_by) do
     side
     |> Map.keys()
-    |> Enum.sort(sort_by)
     |> Enum.take(depth)
+    |> Enum.sort(sort_by)
     |> Enum.map(&%PricePoint{price: &1, size: side |> Map.fetch!(&1)})
   end
 


### PR DESCRIPTION
By default, ProcessQuote receives a full order book from a venue, so
sorting can be quite long. It may not have time to process the message
before receiving a new one, to the process message inbox will grow
reducing available RAM.

**One can reproduce by setting `depth` for bitmex more than 25.**

So quick workaround is to sort after `&Enum.take/2`, it will increase message handling dramatically. 
Another workaround is to move to sort away from ProcessQuote to a client and just trust the input.
@rupurt WDYT?

```
iex(2)> Elixir.Tai.Markets.ProcessQuote_bitmex_xbtusd |> Process.whereis |> Process.info
[
  registered_name: Tai.Markets.ProcessQuote_bitmex_xbtusd,
  current_function: {:lists, :rfmerge2_2, 5},
  initial_call: {:proc_lib, :init_p, 5},
  status: :running,
  message_queue_len: 951,
  links: [#PID<0.569.0>],
  dictionary: [
    "$initial_call": {Tai.Markets.ProcessQuote, :init, 1},
    "$ancestors": [Tai.VenueAdapters.Bitmex.StreamSupervisor_bitmex,
     Tai.Venues.StreamsSupervisor, Tai.Supervisor, #PID<0.495.0>]
  ],
  trap_exit: false,
  error_handler: :error_handler,
  priority: :normal,
  group_leader: #PID<0.494.0>,
  total_heap_size: 165757675,
  heap_size: 66222786,
  stack_size: 35,
  reductions: 171878258,
  garbage_collection: [
    max_heap_size: %{error_logger: true, kill: true, size: 0},
    min_bin_vheap_size: 46422,
    min_heap_size: 233,
    fullsweep_after: 65535,
    minor_gcs: 2
  ],
  suspending: []
]
iex(3)> Elixir.Tai.Markets.ProcessQuote_bitmex_xbtusd |> Process.whereis |> Process.info
[
  registered_name: Tai.Markets.ProcessQuote_bitmex_xbtusd,
  current_function: {:erlang, :>, 2},
  initial_call: {:proc_lib, :init_p, 5},
  status: :running,
  message_queue_len: 1009,
  links: [#PID<0.569.0>],
  dictionary: [
    "$initial_call": {Tai.Markets.ProcessQuote, :init, 1},
    "$ancestors": [Tai.VenueAdapters.Bitmex.StreamSupervisor_bitmex,
     Tai.Venues.StreamsSupervisor, Tai.Supervisor, #PID<0.495.0>]
  ],
  trap_exit: false,
  error_handler: :error_handler,
  priority: :normal,
  group_leader: #PID<0.494.0>,
  total_heap_size: 174416259,
  heap_size: 66222786,
  stack_size: 39,
  reductions: 217805691,
  garbage_collection: [
    max_heap_size: %{error_logger: true, kill: true, size: 0},
    min_bin_vheap_size: 46422,
    min_heap_size: 233,
    fullsweep_after: 65535,
    minor_gcs: 2
  ],
  suspending: []
]
```