### PR TITLE
Order book pubsub

### DIFF
--- a/apps/tai/lib/tai/config.ex
+++ b/apps/tai/lib/tai/config.ex
@@ -6,6 +6,7 @@ defmodule Tai.Config do
   @type t :: %Tai.Config{
           adapter_timeout: integer,
           advisor_groups: map,
+          broadcast_change_set: boolean,
           venue_boot_handler: module,
           event_registry_partitions: pos_integer,
           pub_sub_registry_partitions: pos_integer,
@@ -25,6 +26,7 @@ defmodule Tai.Config do
   defstruct ~w(
     adapter_timeout
     advisor_groups
+    broadcast_change_set
     event_registry_partitions
     pub_sub_registry_partitions
     venue_boot_handler
@@ -35,6 +37,7 @@ defmodule Tai.Config do
   def parse(env \\ Application.get_all_env(:tai)) do
     adapter_timeout = Keyword.get(env, :adapter_timeout, 10_000)
     advisor_groups = Keyword.get(env, :advisor_groups, %{})
+    broadcast_change_set = !!Keyword.get(env, :broadcast_change_set)
     venue_boot_handler = Keyword.get(env, :venue_boot_handler, Tai.Venues.BootHandler)
     send_orders = !!Keyword.get(env, :send_orders)
     venues = Keyword.get(env, :venues, %{})
@@ -48,6 +51,7 @@ defmodule Tai.Config do
     %Tai.Config{
       adapter_timeout: adapter_timeout,
       advisor_groups: advisor_groups,
+      broadcast_change_set: broadcast_change_set,
       event_registry_partitions: event_registry_partitions,
       pub_sub_registry_partitions: pub_sub_registry_partitions,
       venue_boot_handler: venue_boot_handler,

--- a/apps/tai/lib/tai/markets/order_book.ex
+++ b/apps/tai/lib/tai/markets/order_book.ex
@@ -38,6 +38,7 @@ defmodule Tai.Markets.OrderBook do
           bids: %{optional(price) => qty},
           asks: %{optional(price) => qty},
           last_received_at: DateTime.t(),
+          last_change_set: ChangeSet.t(),
           last_venue_timestamp: DateTime.t() | nil
         }
 
@@ -96,7 +97,8 @@ defmodule Tai.Markets.OrderBook do
         | bids: %{},
           asks: %{},
           last_received_at: change_set.last_received_at,
-          last_venue_timestamp: change_set.last_venue_timestamp
+          last_venue_timestamp: change_set.last_venue_timestamp,
+          last_change_set: change_set
       }
       |> apply_changes(change_set.changes)
 
@@ -112,7 +114,8 @@ defmodule Tai.Markets.OrderBook do
       %{
         state
         | last_received_at: change_set.last_received_at,
-          last_venue_timestamp: change_set.last_venue_timestamp
+          last_venue_timestamp: change_set.last_venue_timestamp,
+          last_change_set: change_set
       }
       |> apply_changes(change_set.changes)
 

--- a/apps/tai/lib/tai/markets/order_book.ex
+++ b/apps/tai/lib/tai/markets/order_book.ex
@@ -60,8 +60,18 @@ defmodule Tai.Markets.OrderBook do
     last_venue_timestamp
   )a
 
-  @spec start_link(product) :: GenServer.on_start()
-  def start_link(product, opts \\ []) do
+  @spec child_spec(product, boolean) :: Supervisor.child_spec()
+  def child_spec(product, broadcast_change_set) do
+    %{
+      id: to_name(product.venue_id, product.symbol),
+      start:
+        {__MODULE__, :start_link,
+         [[product: product, broadcast_change_set: broadcast_change_set]]}
+    }
+  end
+
+  @spec start_link(product: product, broadcast_change_set: boolean) :: GenServer.on_start()
+  def start_link(product: product, broadcast_change_set: broadcast_change_set) do
     name = to_name(product.venue_id, product.symbol)
 
     state = %OrderBook{
@@ -69,7 +79,7 @@ defmodule Tai.Markets.OrderBook do
       product_symbol: product.symbol,
       bids: %{},
       asks: %{},
-      broadcast_change_set: !!Keyword.get(opts, :broadcast_change_set)
+      broadcast_change_set: broadcast_change_set
     }
 
     GenServer.start_link(__MODULE__, state, name: name)

--- a/apps/tai/lib/tai/venue.ex
+++ b/apps/tai/lib/tai/venue.ex
@@ -17,6 +17,7 @@ defmodule Tai.Venue do
           credentials: credentials,
           quote_depth: pos_integer,
           timeout: non_neg_integer,
+          broadcast_change_set: boolean,
           opts: map
         }
 
@@ -40,6 +41,7 @@ defmodule Tai.Venue do
     credentials
     quote_depth
     timeout
+    broadcast_change_set
     opts
   )a
 end

--- a/apps/tai/lib/tai/venue_adapters/binance/stream_supervisor.ex
+++ b/apps/tai/lib/tai/venue_adapters/binance/stream_supervisor.ex
@@ -30,7 +30,7 @@ defmodule Tai.VenueAdapters.Binance.StreamSupervisor do
     credential = venue.credentials |> Map.to_list() |> List.first()
 
     market_quote_children = market_quote_children(products, venue.quote_depth)
-    order_book_children = order_book_children(products)
+    order_book_children = order_book_children(products, venue.broadcast_change_set)
     process_order_book_children = process_order_book_children(products)
 
     system = [
@@ -92,14 +92,9 @@ defmodule Tai.VenueAdapters.Binance.StreamSupervisor do
     end)
   end
 
-  defp order_book_children(products) do
+  defp order_book_children(products, broadcast_change_set) do
     products
-    |> Enum.map(fn p ->
-      %{
-        id: OrderBook.to_name(p.venue_id, p.symbol),
-        start: {OrderBook, :start_link, [p]}
-      }
-    end)
+    |> Enum.map(&OrderBook.child_spec(&1, broadcast_change_set))
   end
 
   defp process_order_book_children(products) do

--- a/apps/tai/lib/tai/venue_adapters/bitmex/stream_supervisor.ex
+++ b/apps/tai/lib/tai/venue_adapters/bitmex/stream_supervisor.ex
@@ -31,7 +31,7 @@ defmodule Tai.VenueAdapters.Bitmex.StreamSupervisor do
     credential = venue.credentials |> Map.to_list() |> List.first()
 
     market_quote_children = market_quote_children(products, venue.quote_depth)
-    order_book_children = order_book_children(products)
+    order_book_children = order_book_children(products, venue.broadcast_change_set)
     process_order_book_children = process_order_book_children(products)
 
     system = [
@@ -64,14 +64,9 @@ defmodule Tai.VenueAdapters.Bitmex.StreamSupervisor do
     end)
   end
 
-  defp order_book_children(products) do
+  defp order_book_children(products, broadcast_change_set) do
     products
-    |> Enum.map(fn p ->
-      %{
-        id: OrderBook.to_name(p.venue_id, p.symbol),
-        start: {OrderBook, :start_link, [p]}
-      }
-    end)
+    |> Enum.map(&OrderBook.child_spec(&1, broadcast_change_set))
   end
 
   defp process_order_book_children(products) do

--- a/apps/tai/lib/tai/venue_adapters/deribit/stream_supervisor.ex
+++ b/apps/tai/lib/tai/venue_adapters/deribit/stream_supervisor.ex
@@ -29,7 +29,7 @@ defmodule Tai.VenueAdapters.Deribit.StreamSupervisor do
     credential = venue.credentials |> Map.to_list() |> List.first()
 
     market_quote_children = market_quote_children(products, venue.quote_depth)
-    order_book_children = order_book_children(products)
+    order_book_children = order_book_children(products, venue.broadcast_change_set)
     process_order_book_children = process_order_book_children(products)
 
     system = [
@@ -60,14 +60,9 @@ defmodule Tai.VenueAdapters.Deribit.StreamSupervisor do
     end)
   end
 
-  defp order_book_children(products) do
+  defp order_book_children(products, broadcast_change_set) do
     products
-    |> Enum.map(fn p ->
-      %{
-        id: OrderBook.to_name(p.venue_id, p.symbol),
-        start: {OrderBook, :start_link, [p]}
-      }
-    end)
+    |> Enum.map(&OrderBook.child_spec(&1, broadcast_change_set))
   end
 
   defp process_order_book_children(products) do

--- a/apps/tai/lib/tai/venue_adapters/gdax/stream_supervisor.ex
+++ b/apps/tai/lib/tai/venue_adapters/gdax/stream_supervisor.ex
@@ -30,7 +30,7 @@ defmodule Tai.VenueAdapters.Gdax.StreamSupervisor do
     credential = venue.credentials |> Map.to_list() |> List.first()
 
     market_quote_children = market_quote_children(products, venue.quote_depth)
-    order_book_children = order_book_children(products)
+    order_book_children = order_book_children(products, venue.broadcast_change_set)
     process_order_book_children = process_order_book_children(products)
 
     system = [
@@ -61,14 +61,9 @@ defmodule Tai.VenueAdapters.Gdax.StreamSupervisor do
     end)
   end
 
-  defp order_book_children(products) do
+  defp order_book_children(products, broadcast_change_set) do
     products
-    |> Enum.map(fn p ->
-      %{
-        id: OrderBook.to_name(p.venue_id, p.symbol),
-        start: {OrderBook, :start_link, [p]}
-      }
-    end)
+    |> Enum.map(&OrderBook.child_spec(&1, broadcast_change_set))
   end
 
   defp process_order_book_children(products) do

--- a/apps/tai/lib/tai/venue_adapters/mock/stream_supervisor.ex
+++ b/apps/tai/lib/tai/venue_adapters/mock/stream_supervisor.ex
@@ -19,7 +19,7 @@ defmodule Tai.VenueAdapters.Mock.StreamSupervisor do
     credential = venue.credentials |> Map.to_list() |> List.first()
 
     market_quote_children = market_quote_children(products, venue.quote_depth)
-    order_book_children = order_book_children(products)
+    order_book_children = order_book_children(products, venue.broadcast_change_set)
 
     system = [
       {Tai.VenueAdapters.Mock.Stream.Connection,
@@ -46,14 +46,9 @@ defmodule Tai.VenueAdapters.Mock.StreamSupervisor do
     end)
   end
 
-  defp order_book_children(products) do
+  defp order_book_children(products, broadcast_change_set) do
     products
-    |> Enum.map(fn p ->
-      %{
-        id: OrderBook.to_name(p.venue_id, p.symbol),
-        start: {OrderBook, :start_link, [p]}
-      }
-    end)
+    |> Enum.map(&OrderBook.child_spec(&1, broadcast_change_set))
   end
 
   # TODO: Make this configurable

--- a/apps/tai/lib/tai/venues/config.ex
+++ b/apps/tai/lib/tai/venues/config.ex
@@ -19,7 +19,9 @@ defmodule Tai.Venues.Config do
               credentials: Keyword.get(params, :credentials, %{}),
               quote_depth: Keyword.get(params, :quote_depth, 1),
               opts: Keyword.get(params, :opts, %{}),
-              timeout: Keyword.get(params, :timeout, config.adapter_timeout)
+              timeout: Keyword.get(params, :timeout, config.adapter_timeout),
+              broadcast_change_set:
+                Keyword.get(params, :broadcast_change_set, config.broadcast_change_set)
             }
 
             Map.put(acc, id, venue)

--- a/apps/tai/test/tai/config_test.exs
+++ b/apps/tai/test/tai/config_test.exs
@@ -12,6 +12,7 @@ defmodule Tai.ConfigTest do
                venues: %{},
                advisor_groups: %{},
                adapter_timeout: 10_000,
+               broadcast_change_set: false,
                event_registry_partitions: ^schedulers_online,
                pub_sub_registry_partitions: ^schedulers_online
              } = Tai.Config.parse([])
@@ -45,6 +46,11 @@ defmodule Tai.ConfigTest do
     test "can set advisor_groups" do
       assert config = Tai.Config.parse(advisor_groups: :advisor_groups)
       assert config.advisor_groups == :advisor_groups
+    end
+
+    test "can set broadcast_change_set" do
+      assert config = Tai.Config.parse(broadcast_change_set: true)
+      assert config.broadcast_change_set
     end
   end
 end

--- a/apps/tai/test/tai/venue_adapters/binance/stream/process_order_book_test.exs
+++ b/apps/tai/test/tai/venue_adapters/binance/stream/process_order_book_test.exs
@@ -17,7 +17,7 @@ defmodule Tai.VenueAdapters.Binance.Stream.ProcessOrderBookTest do
     Process.register(self(), @process_quote_name)
     start_supervised!({Tai.PubSub, 1})
     start_supervised!({Tai.Events, 1})
-    start_supervised!({OrderBook, @product})
+    start_supervised!(OrderBook.child_spec(@product, false))
     {:ok, pid} = start_supervised({ProcessOrderBook, @product})
 
     {:ok, %{pid: pid}}

--- a/apps/tai/test/tai/venue_adapters/bitmex/stream/process_order_book_test.exs
+++ b/apps/tai/test/tai/venue_adapters/bitmex/stream/process_order_book_test.exs
@@ -16,7 +16,7 @@ defmodule Tai.VenueAdapters.Bitmex.Stream.ProcessOrderBookTest do
 
   setup do
     start_supervised!({Tai.PubSub, 1})
-    start_supervised!({OrderBook, @product})
+    start_supervised!(OrderBook.child_spec(@product, false))
     {:ok, pid} = start_supervised({ProcessOrderBook, @product})
     Process.register(self(), @process_quote_name)
 

--- a/apps/tai/test/tai/venue_adapters/okex/stream/process_order_book_test.exs
+++ b/apps/tai/test/tai/venue_adapters/okex/stream/process_order_book_test.exs
@@ -16,7 +16,7 @@ defmodule Tai.VenueAdapters.OkEx.Stream.ProcessOrderBookTest do
   setup do
     start_supervised!({Tai.PubSub, 1})
     start_supervised!({Tai.Events, 1})
-    start_supervised!({OrderBook, @product})
+    start_supervised!(OrderBook.child_spec(@product, false))
     {:ok, pid} = start_supervised({ProcessOrderBook, @product})
     Process.register(self(), @process_quote_name)
 

--- a/apps/tai/test/tai/venues/adapters/gdax/stream/process_order_book_test.exs
+++ b/apps/tai/test/tai/venues/adapters/gdax/stream/process_order_book_test.exs
@@ -17,7 +17,7 @@ defmodule Tai.VenueAdapters.Gdax.Stream.ProcessOrderBookTest do
     {:ok, _} = Application.ensure_all_started(:tzdata)
     start_supervised!({Tai.PubSub, 1})
     start_supervised!({Tai.Events, 1})
-    start_supervised!({OrderBook, @product})
+    start_supervised!(OrderBook.child_spec(@product, false))
     {:ok, pid} = start_supervised({ProcessOrderBook, @product})
     Process.register(self(), @process_quote_name)
 

--- a/apps/tai/test/tai/venues/config_test.exs
+++ b/apps/tai/test/tai/venues/config_test.exs
@@ -165,6 +165,22 @@ defmodule Tai.Venues.ConfigTest do
       assert venue.quote_depth == 5
     end
 
+    test "can provide broadcast_change_set" do
+      config =
+        Tai.Config.parse(
+          venues: %{
+            venue_a: [
+              enabled: true,
+              adapter: MyAdapterA,
+              broadcast_change_set: true
+            ]
+          }
+        )
+
+      assert %{venue_a: venue} = Tai.Venues.Config.parse(config)
+      assert venue.broadcast_change_set
+    end
+
     test "raises a KeyError when there is no adapter specified" do
       config = Tai.Config.parse(venues: %{invalid_exchange_a: [enabled: true]})
 

--- a/config/dev.exs.example
+++ b/config/dev.exs.example
@@ -1,6 +1,7 @@
 use Mix.Config
 
 config :tai, send_orders: false
+config :tai, :broadcast_change_set, true
 
 config :tai,
   advisor_groups: %{
@@ -36,6 +37,7 @@ config :tai,
           api_secret: {:system_file, "BITMEX_API_SECRET"}
         }
       },
+      broadcast_change_set: true,
       opts: %{
         autocancel: %{ping_interval_ms: 15_000, cancel_after_ms: 60_000}
       }


### PR DESCRIPTION
This introduces ability to broadcast order book changes to `Tai.PubSub`, allowing capturing of order book outside of the advisor.

Broadcasting is disabled by default, but can be enabled by adding `config :tai, :broadcast_change_set, true`.

Subscribe to the event via: `Tai.PubSub.subscribe(:change_set)`