### PR TITLE
Allow overriding of Tai.EventsLogger logging behaviour using custom logger

### DIFF
--- a/apps/tai/lib/tai/application.ex
+++ b/apps/tai/lib/tai/application.ex
@@ -7,7 +7,7 @@ defmodule Tai.Application do
 
     children = [
       {Tai.SystemBus, config.system_bus_registry_partitions},
-      Tai.EventsLogger,
+      {Tai.EventsLogger, [logger: config.logger]},
       {Tai.Settings, config},
       Tai.Trading.PositionStore,
       Tai.Trading.OrderStore,

--- a/apps/tai/lib/tai/config.ex
+++ b/apps/tai/lib/tai/config.ex
@@ -44,6 +44,7 @@ defmodule Tai.Config do
           after_boot: {handler, func_name} | {handler, func_name, boot_args} | nil,
           after_boot_error: {handler, func_name} | {handler, func_name, boot_args} | nil,
           broadcast_change_set: boolean,
+          logger: module,
           send_orders: boolean,
           system_bus_registry_partitions: pos_integer,
           venues: map
@@ -62,6 +63,7 @@ defmodule Tai.Config do
     after_boot
     after_boot_error
     broadcast_change_set
+    logger
     send_orders
     system_bus_registry_partitions
     venues
@@ -76,6 +78,7 @@ defmodule Tai.Config do
       after_boot: get(env, :after_boot),
       after_boot_error: get(env, :after_boot_error),
       broadcast_change_set: !!get(env, :broadcast_change_set),
+      logger: get(env, :logger),
       send_orders: !!get(env, :send_orders),
       system_bus_registry_partitions:
         get(env, :system_bus_registry_partitions, System.schedulers_online()),

--- a/apps/tai/lib/tai/events_logger.ex
+++ b/apps/tai/lib/tai/events_logger.ex
@@ -1,15 +1,37 @@
 defmodule Tai.EventsLogger do
   use GenServer
-  require Logger
 
   defmodule State do
     @type t :: %State{
             id: atom,
-            events: module
+            events: module,
+            logger: module
           }
 
-    @enforce_keys ~w(id events)a
-    defstruct ~w(id events)a
+    @enforce_keys ~w(id events logger)a
+    defstruct ~w(id events logger)a
+  end
+
+  defmodule DefaultLogger do
+    @behaviour Tai.EventsLogger
+
+    require Logger
+
+    def log(:error, event) do
+      event |> TaiEvents.Event.encode!() |> Logger.error()
+    end
+
+    def log(:warn, event) do
+      event |> TaiEvents.Event.encode!() |> Logger.warn()
+    end
+
+    def log(:info, event) do
+      event |> TaiEvents.Event.encode!() |> Logger.info()
+    end
+
+    def log(:debug, event) do
+      event |> TaiEvents.Event.encode!() |> Logger.debug()
+    end
   end
 
   @type event :: map
@@ -17,15 +39,19 @@ defmodule Tai.EventsLogger do
 
   @default_id :default
   @default_events TaiEvents
+  @default_logger DefaultLogger
 
   def start_link(args) do
     id = Keyword.get(args, :id, @default_id)
     name = :"#{__MODULE__}_#{id}"
     events = Keyword.get(args, :events, @default_events)
-    state = %State{id: id, events: events}
+    logger = Keyword.get(args, :logger) || @default_logger
+    state = %State{id: id, events: events, logger: logger}
 
     GenServer.start_link(__MODULE__, state, name: name)
   end
+
+  @callback log(level, event) :: :ok
 
   @spec init(State.t()) :: {:ok, State.t()}
   def init(state) do
@@ -34,23 +60,8 @@ defmodule Tai.EventsLogger do
   end
 
   @spec handle_info({TaiEvents.Event, event, level}, State.t()) :: {:noreply, State.t()}
-  def handle_info({TaiEvents.Event, event, :error}, state) do
-    event |> TaiEvents.Event.encode!() |> Logger.error()
-    {:noreply, state}
-  end
-
-  def handle_info({TaiEvents.Event, event, :warn}, state) do
-    event |> TaiEvents.Event.encode!() |> Logger.warn()
-    {:noreply, state}
-  end
-
-  def handle_info({TaiEvents.Event, event, :info}, state) do
-    event |> TaiEvents.Event.encode!() |> Logger.info()
-    {:noreply, state}
-  end
-
-  def handle_info({TaiEvents.Event, event, :debug}, state) do
-    event |> TaiEvents.Event.encode!() |> Logger.debug()
+  def handle_info({TaiEvents.Event, event, level}, state) do
+    state.logger.log(level, event)
     {:noreply, state}
   end
 end

--- a/apps/tai/test/tai/config_test.exs
+++ b/apps/tai/test/tai/config_test.exs
@@ -10,6 +10,7 @@ defmodule Tai.ConfigTest do
       assert config.after_boot == nil
       assert config.after_boot_error == nil
       assert config.broadcast_change_set == false
+      assert config.logger == nil
       assert config.send_orders == false
       assert config.system_bus_registry_partitions == System.schedulers_online()
       assert config.venues == %{}
@@ -43,6 +44,11 @@ defmodule Tai.ConfigTest do
     test "can set system_bus_registry_partitions" do
       assert config = Tai.Config.parse(system_bus_registry_partitions: 1)
       assert config.system_bus_registry_partitions == 1
+    end
+
+    test "can set logger" do
+      assert config = Tai.Config.parse(logger: CustomLogger)
+      assert config.logger == CustomLogger
     end
 
     test "can set send_orders" do

--- a/apps/tai/test/tai/events_logger_test.exs
+++ b/apps/tai/test/tai/events_logger_test.exs
@@ -52,4 +52,21 @@ defmodule Tai.EventsLoggerTest do
              :timer.sleep(100)
            end) =~ "[debug] {\"data\":{\"hello\":\"custom\"},\"type\":\"Support.CustomEvent\"}"
   end
+
+  test "logs with custom logger" do
+    defmodule CustomLogger do
+      require Logger
+
+      def log(level, _event) do
+        Logger.log(level, "message from custom logger")
+      end
+    end
+
+    logger = start_supervised!({Tai.EventsLogger, id: __MODULE__, logger: CustomLogger})
+
+    assert capture_log(fn ->
+             send(logger, {TaiEvents.Event, @event, :info})
+             :timer.sleep(100)
+           end) =~ "[info]  message from custom logger"
+  end
 end


### PR DESCRIPTION
By specifying our custom logger, we can override the default logging behaviour:

```elixir
defmodule CustomLogger do
  require Logger

  def log(level, _event) do
    Logger.log(level, "message from custom logger")
  end
end

config :tai, logger: CustomLogger
```