### PR TITLE
Fix Github CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,11 @@ jobs:
       - uses: actions/checkout@v1.0.0
 
       - name: set environment variables
-        uses: allenevans/set-env@v1.1.0
+        uses: allenevans/set-env@v2.0.0
         with:
           CACHE_VERSION: 'kqY3/N+/7OrXUbQJ'
 
-      - uses: actions/setup-elixir@v1.3.0
+      - uses: actions/setup-elixir@v1.5.0
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}


### PR DESCRIPTION
Removes these errors and fixes CI

```
Error: Unable to process command '::set-env name=CACHE_VERSION,::kqY3/N+/7OrXUbQJ' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```